### PR TITLE
feat(api): add Google OAuth support for authentication and account linking

### DIFF
--- a/apps/api/src/application/use-cases/account-link/account-link-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/account-link/account-link-callback.usecase.ts
@@ -73,12 +73,9 @@ export class AccountLinkCallbackUseCase implements IAccountLinkCallbackUseCase {
 			}
 		}
 
-		const tokens = tokensResult;
-		const accessToken = tokens.accessToken();
+		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(tokensResult);
 
-		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(accessToken);
-
-		await this.oauthProviderGateway.revokeToken(accessToken);
+		await this.oauthProviderGateway.revokeToken(tokensResult);
 
 		if (isErr(accountInfoResult)) {
 			switch (accountInfoResult.code) {

--- a/apps/api/src/application/use-cases/account-link/account-link-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/account-link/account-link-callback.usecase.ts
@@ -85,6 +85,8 @@ export class AccountLinkCallbackUseCase implements IAccountLinkCallbackUseCase {
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
 				case "FAILED_TO_GET_ACCOUNT_INFO":
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
+				case "OAUTH_ACCOUNT_INFO_INVALID":
+					return err("OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: redirectToClientURL });
 				default:
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
 			}

--- a/apps/api/src/application/use-cases/account-link/get-connections.usecase.ts
+++ b/apps/api/src/application/use-cases/account-link/get-connections.usecase.ts
@@ -24,6 +24,7 @@ export class GetConnectionsUseCase implements IGetConnectionsUseCase {
 			} | null;
 		} = {
 			discord: null,
+			google: null,
 		};
 
 		const oauthAccounts = await this.oauthAccountRepository.findByUserId(userId);

--- a/apps/api/src/application/use-cases/account-link/interfaces/account-link-callback.usecase.interface.ts
+++ b/apps/api/src/application/use-cases/account-link/interfaces/account-link-callback.usecase.interface.ts
@@ -14,7 +14,8 @@ type Error =
 	| Err<"OAUTH_ACCESS_DENIED", { redirectURL: URL }>
 	| Err<"OAUTH_PROVIDER_ERROR", { redirectURL: URL }>
 	| Err<"OAUTH_PROVIDER_ALREADY_LINKED", { redirectURL: URL }>
-	| Err<"OAUTH_ACCOUNT_ALREADY_LINKED_TO_ANOTHER_USER", { redirectURL: URL }>;
+	| Err<"OAUTH_ACCOUNT_ALREADY_LINKED_TO_ANOTHER_USER", { redirectURL: URL }>
+	| Err<"OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: URL }>;
 
 export type AccountLinkCallbackUseCaseResult = Result<Success, Error>;
 

--- a/apps/api/src/application/use-cases/oauth/interfaces/oauth-login-callback.usecase.interface.ts
+++ b/apps/api/src/application/use-cases/oauth/interfaces/oauth-login-callback.usecase.interface.ts
@@ -18,6 +18,7 @@ type Error =
 	| Err<"OAUTH_ACCESS_DENIED", { redirectURL: URL }>
 	| Err<"OAUTH_PROVIDER_ERROR", { redirectURL: URL }>
 	| Err<"OAUTH_ACCOUNT_NOT_FOUND", { redirectURL: URL }>
+	| Err<"OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: URL }>
 	| Err<
 			"OAUTH_ACCOUNT_NOT_FOUND_BUT_LINKABLE",
 			{

--- a/apps/api/src/application/use-cases/oauth/interfaces/oauth-signup-callback.usecase.interface.ts
+++ b/apps/api/src/application/use-cases/oauth/interfaces/oauth-signup-callback.usecase.interface.ts
@@ -18,6 +18,7 @@ type Error =
 	| Err<"OAUTH_ACCESS_DENIED", { redirectURL: URL }>
 	| Err<"OAUTH_PROVIDER_ERROR", { redirectURL: URL }>
 	| Err<"OAUTH_ACCOUNT_ALREADY_REGISTERED", { redirectURL: URL }>
+	| Err<"OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: URL }>
 	| Err<
 			"OAUTH_EMAIL_ALREADY_REGISTERED_BUT_LINKABLE",
 			{

--- a/apps/api/src/application/use-cases/oauth/oauth-login-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/oauth/oauth-login-callback.usecase.ts
@@ -86,12 +86,9 @@ export class OAuthLoginCallbackUseCase implements IOAuthLoginCallbackUseCase {
 			}
 		}
 
-		const tokens = tokensResult;
-		const accessToken = tokens.accessToken();
+		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(tokensResult);
 
-		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(accessToken);
-
-		await this.oauthProviderGateway.revokeToken(accessToken);
+		await this.oauthProviderGateway.revokeToken(tokensResult);
 
 		if (isErr(accountInfoResult)) {
 			switch (accountInfoResult.code) {

--- a/apps/api/src/application/use-cases/oauth/oauth-login-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/oauth/oauth-login-callback.usecase.ts
@@ -98,6 +98,8 @@ export class OAuthLoginCallbackUseCase implements IOAuthLoginCallbackUseCase {
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
 				case "OAUTH_ACCOUNT_EMAIL_NOT_FOUND":
 					return err("OAUTH_ACCOUNT_EMAIL_NOT_FOUND", { redirectURL: redirectToClientURL });
+				case "OAUTH_ACCOUNT_INFO_INVALID":
+					return err("OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: redirectToClientURL });
 				default:
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
 			}

--- a/apps/api/src/application/use-cases/oauth/oauth-signup-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/oauth/oauth-signup-callback.usecase.ts
@@ -95,12 +95,9 @@ export class OAuthSignupCallbackUseCase implements IOAuthSignupCallbackUseCase {
 			}
 		}
 
-		const tokens = tokensResult;
-		const accessToken = tokens.accessToken();
+		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(tokensResult);
 
-		const accountInfoResult = await this.oauthProviderGateway.getAccountInfo(accessToken);
-
-		await this.oauthProviderGateway.revokeToken(accessToken);
+		await this.oauthProviderGateway.revokeToken(tokensResult);
 
 		if (isErr(accountInfoResult)) {
 			switch (accountInfoResult.code) {

--- a/apps/api/src/application/use-cases/oauth/oauth-signup-callback.usecase.ts
+++ b/apps/api/src/application/use-cases/oauth/oauth-signup-callback.usecase.ts
@@ -103,6 +103,8 @@ export class OAuthSignupCallbackUseCase implements IOAuthSignupCallbackUseCase {
 			switch (accountInfoResult.code) {
 				case "OAUTH_ACCOUNT_EMAIL_NOT_FOUND":
 					return err("OAUTH_ACCOUNT_EMAIL_NOT_FOUND", { redirectURL: redirectToClientURL });
+				case "OAUTH_ACCOUNT_INFO_INVALID":
+					return err("OAUTH_ACCOUNT_INFO_INVALID", { redirectURL: redirectToClientURL });
 				case "OAUTH_ACCESS_TOKEN_INVALID":
 					return err("FAILED_TO_FETCH_OAUTH_ACCOUNT", { redirectURL: redirectToClientURL });
 				case "FAILED_TO_GET_ACCOUNT_INFO":

--- a/apps/api/src/domain/value-object/oauth-provider.ts
+++ b/apps/api/src/domain/value-object/oauth-provider.ts
@@ -1,13 +1,13 @@
 import { StringEnum } from "../../common/schemas";
-import type { NewType } from "../../common/utils";
+import type { NewType, ToPrimitive } from "../../common/utils";
 
-export type OAuthProvider = NewType<"oauth-provider", "discord">;
+export type OAuthProvider = NewType<"oauth-provider", "discord" | "google">;
 
-export const newOAuthProvider = (raw: "discord") => {
+export const newOAuthProvider = (raw: ToPrimitive<OAuthProvider>) => {
 	return raw as OAuthProvider;
 };
 
-export const oauthProviderSchema = StringEnum(["discord"]);
+export const oauthProviderSchema = StringEnum(["discord", "google"]);
 
 export type OAuthProviderId = NewType<"OAuthProviderId", string>;
 

--- a/apps/api/src/infrastructure/drizzle/schema/account-association-sessions.ts
+++ b/apps/api/src/infrastructure/drizzle/schema/account-association-sessions.ts
@@ -11,7 +11,7 @@ export const accountAssociationSessions = sqliteTable(
 		secretHash: blob("secret_hash", { mode: "buffer" }).notNull(),
 		code: text("code"),
 		email: text("email").notNull(),
-		provider: text("provider", { enum: ["discord"] }).notNull(),
+		provider: text("provider", { enum: ["discord", "google"] }).notNull(),
 		providerId: text("provider_id").notNull(),
 		expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
 	},

--- a/apps/api/src/infrastructure/drizzle/schema/oauth-accounts.ts
+++ b/apps/api/src/infrastructure/drizzle/schema/oauth-accounts.ts
@@ -5,7 +5,7 @@ import { users } from "./users";
 export const oauthAccounts = sqliteTable(
 	"oauth_accounts",
 	{
-		provider: text("provider", { enum: ["discord"] }).notNull(),
+		provider: text("provider", { enum: ["discord", "google"] }).notNull(),
 		providerId: text("provider_id").notNull(),
 		userId: text("user_id")
 			.notNull()

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/interfaces/oauth-provider.gateway.interface.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/interfaces/oauth-provider.gateway.interface.ts
@@ -16,7 +16,10 @@ export type GetTokensResult = Result<
 
 export type GetAccountInfoResult = Result<
 	AccountInfo,
-	Err<"FAILED_TO_GET_ACCOUNT_INFO"> | Err<"OAUTH_ACCESS_TOKEN_INVALID"> | Err<"OAUTH_ACCOUNT_EMAIL_NOT_FOUND">
+	| Err<"FAILED_TO_GET_ACCOUNT_INFO">
+	| Err<"OAUTH_ACCESS_TOKEN_INVALID">
+	| Err<"OAUTH_ACCOUNT_EMAIL_NOT_FOUND">
+	| Err<"OAUTH_ACCOUNT_INFO_INVALID">
 >;
 
 export interface IOAuthProviderGateway {

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/interfaces/oauth-provider.gateway.interface.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/interfaces/oauth-provider.gateway.interface.ts
@@ -22,6 +22,6 @@ export type GetAccountInfoResult = Result<
 export interface IOAuthProviderGateway {
 	genAuthURL(state: string, codeVerifier: string): URL;
 	getTokens(code: string, codeVerifier: string): Promise<GetTokensResult>;
-	getAccountInfo(accessToken: string): Promise<GetAccountInfoResult>;
-	revokeToken(token: string): Promise<void>;
+	getAccountInfo(tokens: GetTokensResult): Promise<GetAccountInfoResult>;
+	revokeToken(tokens: OAuth2Tokens): Promise<void>;
 }

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/oauth-provider.gateway.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/oauth-provider.gateway.ts
@@ -2,6 +2,7 @@ import type { OAuthProvider } from "../../../domain/value-object";
 import type { OAuthProviderEnv } from "../../../modules/env";
 import type { IOAuthProviderGateway } from "./interfaces/oauth-provider.gateway.interface";
 import { DiscordOAuthGateway } from "./providers/discord.gateway";
+import { GoogleOAuthGateway } from "./providers/google.gateway";
 
 const OAuthProviderGateway = (
 	env: OAuthProviderEnv,
@@ -11,6 +12,8 @@ const OAuthProviderGateway = (
 	switch (provider) {
 		case "discord":
 			return new DiscordOAuthGateway(env.DISCORD_CLIENT_ID, env.DISCORD_CLIENT_SECRET, redirectURI);
+		case "google":
+			return new GoogleOAuthGateway(env.GOOGLE_CLIENT_ID, env.GOOGLE_CLIENT_SECRET, redirectURI);
 		default:
 			throw new Error(`Unsupported OAuth provider: ${provider}`);
 	}

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/providers/discord.gateway.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/providers/discord.gateway.ts
@@ -83,7 +83,7 @@ export class DiscordOAuthGateway implements IOAuthProviderGateway {
 			const user = await response.json();
 
 			if (!Value.Check(discordAccountInfoSchema, user)) {
-				return err("FAILED_TO_GET_ACCOUNT_INFO");
+				return err("OAUTH_ACCOUNT_INFO_INVALID");
 			}
 
 			if (!user.email) {

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/providers/google.gateway.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/providers/google.gateway.ts
@@ -1,11 +1,12 @@
 import { Value } from "@sinclair/typebox/value";
 import {
 	ArcticFetchError,
-	Discord as DiscordProvider,
+	Google as GoogleProvider,
 	OAuth2RequestError,
 	type OAuth2Tokens,
 	UnexpectedErrorResponseBodyError,
 	UnexpectedResponseError,
+	decodeIdToken,
 } from "arctic";
 import { t } from "elysia";
 import { err } from "../../../../common/utils";
@@ -15,37 +16,34 @@ import type {
 	IOAuthProviderGateway,
 } from "../interfaces/oauth-provider.gateway.interface";
 
-const discordAccountInfoSchema = t.Object({
-	id: t.String(),
-	username: t.String(),
-	discriminator: t.String(),
-	global_name: t.Union([t.String(), t.Null()]),
-	avatar: t.Union([t.String(), t.Null()]),
-	banner: t.Union([t.String(), t.Null()]),
-	accent_color: t.Union([t.Integer(), t.Null()]),
-	verified: t.Union([t.Boolean(), t.Null()]),
-	email: t.Union([t.String({ format: "email" }), t.Null()]),
+const googleIdTokenClaimsSchema = t.Object({
+	sub: t.String(),
+	name: t.String(),
+	email: t.String(),
+	picture: t.Optional(t.String()),
+	email_verified: t.Optional(t.Boolean()),
 });
 
-export class DiscordOAuthGateway implements IOAuthProviderGateway {
-	private readonly discord: DiscordProvider;
-	private readonly scope = ["identify", "email"];
+export class GoogleOAuthGateway implements IOAuthProviderGateway {
+	private readonly google: GoogleProvider;
+	private readonly scope = ["openid", "profile", "email"];
 
 	constructor(clientId: string, clientSecret: string, redirectURI: string) {
-		this.discord = new DiscordProvider(clientId, clientSecret, redirectURI);
+		this.google = new GoogleProvider(clientId, clientSecret, redirectURI);
 	}
 
 	public genAuthURL(state: string, codeVerifier: string): URL {
-		const url = this.discord.createAuthorizationURL(state, codeVerifier, this.scope);
+		const url = this.google.createAuthorizationURL(state, codeVerifier, this.scope);
 		return url;
 	}
 
 	public async getTokens(code: string, codeVerifier: string): Promise<GetTokensResult> {
 		try {
-			const tokens = await this.discord.validateAuthorizationCode(code, codeVerifier);
+			const tokens = await this.google.validateAuthorizationCode(code, codeVerifier);
 			return tokens;
 		} catch (error) {
 			if (error instanceof OAuth2RequestError) {
+				console.error(error);
 				return err("OAUTH_CREDENTIALS_INVALID");
 			}
 			if (error instanceof ArcticFetchError) {
@@ -65,37 +63,20 @@ export class DiscordOAuthGateway implements IOAuthProviderGateway {
 
 	public async getAccountInfo(tokens: OAuth2Tokens): Promise<GetAccountInfoResult> {
 		try {
-			const accessToken = tokens.accessToken();
+			const idToken = tokens.idToken();
 
-			const response = await fetch("https://discord.com/api/v10/users/@me", {
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-				},
-			});
+			const claims = decodeIdToken(idToken);
 
-			if (!response.ok) {
-				if (response.status === 401) {
-					return err("OAUTH_ACCESS_TOKEN_INVALID");
-				}
+			if (!Value.Check(googleIdTokenClaimsSchema, claims)) {
 				return err("FAILED_TO_GET_ACCOUNT_INFO");
-			}
-
-			const user = await response.json();
-
-			if (!Value.Check(discordAccountInfoSchema, user)) {
-				return err("FAILED_TO_GET_ACCOUNT_INFO");
-			}
-
-			if (!user.email) {
-				return err("OAUTH_ACCOUNT_EMAIL_NOT_FOUND");
 			}
 
 			return {
-				id: user.id,
-				name: user.username,
-				email: user.email,
-				iconURL: user.avatar ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png` : null,
-				emailVerified: !!user.verified,
+				id: claims.sub,
+				name: claims.name,
+				email: claims.email,
+				iconURL: claims.picture ?? null,
+				emailVerified: claims.email_verified ?? false,
 			};
 		} catch (error) {
 			console.error("Error in getAccountInfo:", error);
@@ -105,7 +86,7 @@ export class DiscordOAuthGateway implements IOAuthProviderGateway {
 
 	public async revokeToken(tokens: OAuth2Tokens): Promise<void> {
 		try {
-			await this.discord.revokeToken(tokens.accessToken());
+			await this.google.revokeToken(tokens.accessToken());
 		} catch (error) {
 			console.error("revokeToken request error", error);
 		}

--- a/apps/api/src/interface-adapter/gateway/oauth-provider/providers/google.gateway.ts
+++ b/apps/api/src/interface-adapter/gateway/oauth-provider/providers/google.gateway.ts
@@ -68,7 +68,7 @@ export class GoogleOAuthGateway implements IOAuthProviderGateway {
 			const claims = decodeIdToken(idToken);
 
 			if (!Value.Check(googleIdTokenClaimsSchema, claims)) {
-				return err("FAILED_TO_GET_ACCOUNT_INFO");
+				return err("OAUTH_ACCOUNT_INFO_INVALID");
 			}
 
 			return {

--- a/apps/api/src/interface-adapter/presenter/account-connections.presenter.ts
+++ b/apps/api/src/interface-adapter/presenter/account-connections.presenter.ts
@@ -6,7 +6,7 @@ export const AccountConnectionsPresenterResultSchema = t.Composite([
 	t.Object({
 		password: t.Boolean(),
 	}),
-	t.Mapped(t.Union([t.Literal("discord")]), () =>
+	t.Mapped(t.Union([t.Literal("discord"), t.Literal("google")]), () =>
 		t.Nullable(
 			t.Object({
 				provider: t.String(),
@@ -57,5 +57,6 @@ export const AccountConnectionsPresenter = (
 	return {
 		password,
 		discord: formattedProviders.discord || null,
+		google: formattedProviders.google || null,
 	};
 };

--- a/apps/api/src/interface-adapter/repositories/account-association-session/account-association-session.repository.ts
+++ b/apps/api/src/interface-adapter/repositories/account-association-session/account-association-session.repository.ts
@@ -1,7 +1,9 @@
 import { eq, lte } from "drizzle-orm";
+import type { ToPrimitive } from "../../../common/utils";
 import type { AccountAssociationSession } from "../../../domain/entities";
 import {
 	type AccountAssociationSessionId,
+	type OAuthProvider,
 	type UserId,
 	newAccountAssociationSessionId,
 	newOAuthProvider,
@@ -17,7 +19,7 @@ interface FoundAccountAssociationSessionDto {
 	code: string | null;
 	secretHash: Buffer;
 	email: string;
-	provider: "discord";
+	provider: ToPrimitive<OAuthProvider>;
 	providerId: string;
 	expiresAt: Date;
 }

--- a/apps/api/src/interface-adapter/repositories/oauth-account/oauth-account.repository.ts
+++ b/apps/api/src/interface-adapter/repositories/oauth-account/oauth-account.repository.ts
@@ -1,4 +1,5 @@
 import { and, eq } from "drizzle-orm";
+import type { ToPrimitive } from "../../../common/utils";
 import type { OAuthAccount } from "../../../domain/entities";
 import {
 	type OAuthProvider,
@@ -12,7 +13,7 @@ import type { DrizzleService } from "../../../infrastructure/drizzle";
 import type { IOAuthAccountRepository } from "./interfaces/oauth-account.repository.interface";
 
 interface FoundOAuthAccountDto {
-	provider: "discord";
+	provider: ToPrimitive<OAuthProvider>;
 	providerId: string;
 	userId: string;
 	linkedAt: Date;

--- a/apps/api/src/routes/auth/account-link/account-link-callback.ts
+++ b/apps/api/src/routes/auth/account-link/account-link-callback.ts
@@ -194,6 +194,7 @@ export const AccountLinkCallback = new ElysiaWithEnv()
 					"- **OAUTH_PROVIDER_ERROR**",
 					"- **OAUTH_PROVIDER_ALREADY_LINKED**",
 					"- **OAUTH_ACCOUNT_ALREADY_LINKED_TO_ANOTHER_USER**",
+					"- **OAUTH_ACCOUNT_INFO_INVALID**",
 				],
 				tag: "Auth - Account Link",
 				withAuth: true,

--- a/apps/api/src/routes/auth/oauth/login-callback.ts
+++ b/apps/api/src/routes/auth/oauth/login-callback.ts
@@ -248,6 +248,7 @@ export const OAuthLoginCallback = new ElysiaWithEnv()
 					"- **OAUTH_ACCOUNT_NOT_FOUND**",
 					"- **OAUTH_ACCOUNT_EMAIL_NOT_FOUND**",
 					"- **OAUTH_ACCOUNT_NOT_FOUND_BUT_LINKABLE**",
+					"- **OAUTH_ACCOUNT_INFO_INVALID**",
 				],
 				tag: "Auth - OAuth",
 			}),

--- a/apps/api/src/routes/auth/oauth/signup-callback.ts
+++ b/apps/api/src/routes/auth/oauth/signup-callback.ts
@@ -253,6 +253,7 @@ export const OAuthSignupCallback = new ElysiaWithEnv()
 					"- **OAUTH_ACCOUNT_EMAIL_NOT_FOUND**",
 					"- **OAUTH_ACCOUNT_NOT_FOUND_BUT_LINKABLE**",
 					"- **OAUTH_ACCOUNT_ALREADY_REGISTERED**",
+					"- **OAUTH_ACCOUNT_INFO_INVALID**",
 				],
 				tag: "Auth - OAuth",
 			}),

--- a/apps/api/src/tests/helpers/account-association-session-table.ts
+++ b/apps/api/src/tests/helpers/account-association-session-table.ts
@@ -1,7 +1,9 @@
 import { env } from "cloudflare:test";
 import { SessionSecretService, createSessionToken } from "../../application/services/session";
+import type { ToPrimitive } from "../../common/utils";
 import type { AccountAssociationSession } from "../../domain/entities";
 import {
+	type OAuthProvider,
 	newAccountAssociationSessionId,
 	newOAuthProvider,
 	newOAuthProviderId,
@@ -15,7 +17,7 @@ export type DatabaseAccountAssociationSession = {
 	code: string | null;
 	secret_hash: Array<number>;
 	email: string;
-	provider: "discord";
+	provider: ToPrimitive<OAuthProvider>;
 	provider_id: string;
 	expires_at: number;
 };

--- a/apps/api/src/tests/helpers/oauth-account-table.ts
+++ b/apps/api/src/tests/helpers/oauth-account-table.ts
@@ -1,8 +1,9 @@
+import type { ToPrimitive } from "../../common/utils";
 import type { OAuthAccount } from "../../domain/entities";
-import { newOAuthProvider, newOAuthProviderId, newUserId } from "../../domain/value-object";
+import { type OAuthProvider, newOAuthProvider, newOAuthProviderId, newUserId } from "../../domain/value-object";
 
 export type DatabaseOAuthAccount = {
-	provider: "discord";
+	provider: ToPrimitive<OAuthProvider>;
 	provider_id: string;
 	user_id: string;
 	linked_at: number;
@@ -33,7 +34,10 @@ export class OAuthAccountTableHelper {
 			.run();
 	}
 
-	public async findByProviderAndProviderId(provider: "discord", providerId: string): Promise<DatabaseOAuthAccount[]> {
+	public async findByProviderAndProviderId(
+		provider: OAuthProvider,
+		providerId: string,
+	): Promise<DatabaseOAuthAccount[]> {
 		const { results } = await this.db
 			.prepare("SELECT * FROM oauth_accounts WHERE provider = ?1 AND provider_id = ?2")
 			.bind(provider, providerId)
@@ -42,7 +46,7 @@ export class OAuthAccountTableHelper {
 		return results;
 	}
 
-	public async findByUserIdAndProvider(userId: string, provider: "discord"): Promise<DatabaseOAuthAccount[]> {
+	public async findByUserIdAndProvider(userId: string, provider: OAuthProvider): Promise<DatabaseOAuthAccount[]> {
 		const { results } = await this.db
 			.prepare("SELECT * FROM oauth_accounts WHERE user_id = ?1 AND provider = ?2")
 			.bind(userId, provider)

--- a/apps/api/src/tests/mocks/services/oauth-provider.gateway.mock.ts
+++ b/apps/api/src/tests/mocks/services/oauth-provider.gateway.mock.ts
@@ -18,7 +18,7 @@ export class OAuthProviderGatewayMock implements IOAuthProviderGateway {
 		} as unknown as OAuth2Tokens;
 	}
 
-	public async getAccountInfo(_accessToken: string): Promise<GetAccountInfoResult> {
+	public async getAccountInfo(_tokens: OAuth2Tokens): Promise<GetAccountInfoResult> {
 		return {
 			id: "provider_user_id",
 			email: "test@example.com",
@@ -28,7 +28,7 @@ export class OAuthProviderGatewayMock implements IOAuthProviderGateway {
 		};
 	}
 
-	public async revokeToken(_token: string): Promise<void> {
+	public async revokeToken(_tokens: OAuth2Tokens): Promise<void> {
 		// Mock implementation - no-op
 	}
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -21,9 +21,11 @@ export default function Page(): JSX.Element {
 					// biome-ignore lint/suspicious/noConsoleLog: <explanation>
 					console.log(token);
 				}}
-			/>
+			/> */}
 			<a href="http://localhost:8787/auth/discord/signup?redirect-uri=/&client-type=web">signup with discord</a>
 			<a href="http://localhost:8787/auth/discord/login?redirect-uri=/&client-type=web">login with discord</a>
+			<a href="http://localhost:8787/auth/google/signup?redirect-uri=/&client-type=web">signup with google</a>
+			<a href="http://localhost:8787/auth/google/login?redirect-uri=/&client-type=web">login with google</a>
 			<button
 				type="button"
 				onClick={async () => {
@@ -135,7 +137,7 @@ export default function Page(): JSX.Element {
 				}}
 			>
 				account-association-preview
-			</button> */}
+			</button>
 		</main>
 	);
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -133,6 +133,7 @@ export default function Page(): JSX.Element {
 
 					const data = await res.json();
 
+					// biome-ignore lint/suspicious/noConsoleLog: <explanation>
 					console.log(data);
 				}}
 			>


### PR DESCRIPTION
## ⭐️ Overview(概要)

既存のDiscord OAuth認証に加えて、新しくGoogle OAuth認証のサポートを追加した

## 📝 Changes Made(変更点)

- **GoogleOAuthGateway実装**: Google OAuth認証のためのゲートウェイクラスを新規作成
- **OAuth Provider拡張**: `OAuthProvider`型に`"google"`を追加し、関連するスキーマを更新
- **Use Cases更新**: OAuth関連のユースケース（ログイン、サインアップ、アカウントリンク）にGoogleサポートを追加
- **エラーハンドリング強化**: `OAUTH_ACCOUNT_INFO_INVALID`エラーを追加してアカウント情報取得時のエラーハンドリングを改善
- **データベーススキーマ更新**: OAuth関連テーブルでGoogleプロバイダーをサポート
- **プレゼンター更新**: アカウント接続プレゼンターにGoogleプロバイダーを追加
- **テストヘルパー更新**: テスト用のヘルパー関数とモックをGoogle対応に更新

## 🗺️ Scope of Impact(影響範囲)

- **認証システム**: 新しいOAuthプロバイダーの追加により、認証フローが拡張
- **アカウントリンク機能**: 既存アカウントにGoogleアカウントを連携可能
- **API エンドポイント**: 既存のOAuthエンドポイント（`/auth/google/*`）でGoogleをサポート
- **データベース**: OAuth関連テーブルでGoogleプロバイダーデータを保存

## 🧪 Testing(テスト)

- OAuth関連のユースケースのテストヘルパーを更新
- Google OAuthゲートウェイのモック実装を追加
- 型安全性を向上させるためのToPrimitive型の使用

## 🚓 Related Issue(関連する問題)

- close #83 

## 🔗 External URL(外部リンク)

- [Google OAuth 2.0 Documentation](https://developers.google.com/identity/protocols/oauth2)
- [Arctic Library - Google Provider](https://arctic.js.org/providers/google)